### PR TITLE
strict selective pulling

### DIFF
--- a/aalto/src/main/scala/scales/aalto/parser/pull/AsyncParser.scala
+++ b/aalto/src/main/scala/scales/aalto/parser/pull/AsyncParser.scala
@@ -138,7 +138,7 @@ abstract class AsyncParser(implicit xmlVersion : XmlVersion) extends CloseOnNeed
    */
   protected def pumpMisc() : Input[PullType] = {
 
-    val (event, num, odepth, oprolog) = PullUtils.pumpEvent(parser, strategy, token, prolog, depth)(eventHandler)
+    val (event, num, odepth, oprolog, _) = PullUtils.pumpEvent(parser, strategy, token, prolog, depth)(eventHandler)
 
     depth = odepth
 
@@ -196,7 +196,7 @@ abstract class AsyncParser(implicit xmlVersion : XmlVersion) extends CloseOnNeed
       r
     } else {
       // 2nd > events
-      val (event, num, odepth, oprolog) = PullUtils.pumpEvent(parser, strategy, token, prolog, depth)(eventHandler)
+      val (event, num, odepth, oprolog, _) = PullUtils.pumpEvent(parser, strategy, token, prolog, depth)(eventHandler)
 
       depth = odepth
 

--- a/core-tests/src/test/resources/data/plant_catalog.xml
+++ b/core-tests/src/test/resources/data/plant_catalog.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CATALOG>
+    <PLANTS>
+        <PLANT>
+            <COMMON>Bloodroot</COMMON>
+            <BOTANICAL>Sanguinaria canadensis</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$2.44</PRICE>
+            <AVAILABILITY>031599</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Columbine</COMMON>
+            <BOTANICAL>Aquilegia canadensis</BOTANICAL>
+            <ZONE>3</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$9.37</PRICE>
+            <AVAILABILITY>030699</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Marsh Marigold</COMMON>
+            <BOTANICAL>Caltha palustris</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Mostly Sunny</LIGHT>
+            <PRICE>$6.81</PRICE>
+            <AVAILABILITY>051799</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Cowslip</COMMON>
+            <BOTANICAL>Caltha palustris</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$9.90</PRICE>
+            <AVAILABILITY>030699</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Dutchman's-Breeches</COMMON>
+            <BOTANICAL>Dicentra cucullaria</BOTANICAL>
+            <ZONE>3</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$6.44</PRICE>
+            <AVAILABILITY>012099</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Ginger, Wild</COMMON>
+            <BOTANICAL>Asarum canadense</BOTANICAL>
+            <ZONE>3</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$9.03</PRICE>
+            <AVAILABILITY>041899</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Hepatica</COMMON>
+            <BOTANICAL>Hepatica americana</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$4.45</PRICE>
+            <AVAILABILITY>012699</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Liverleaf</COMMON>
+            <BOTANICAL>Hepatica americana</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$3.99</PRICE>
+            <AVAILABILITY>010299</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Jack-In-The-Pulpit</COMMON>
+            <BOTANICAL>Arisaema triphyllum</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$3.23</PRICE>
+            <AVAILABILITY>020199</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Mayapple</COMMON>
+            <BOTANICAL>Podophyllum peltatum</BOTANICAL>
+            <ZONE>3</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$2.98</PRICE>
+            <AVAILABILITY>060599</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Phlox, Woodland</COMMON>
+            <BOTANICAL>Phlox divaricata</BOTANICAL>
+            <ZONE>3</ZONE>
+            <LIGHT>Sun or Shade</LIGHT>
+            <PRICE>$2.80</PRICE>
+            <AVAILABILITY>012299</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Phlox, Blue</COMMON>
+            <BOTANICAL>Phlox divaricata</BOTANICAL>
+            <ZONE>3</ZONE>
+            <LIGHT>Sun or Shade</LIGHT>
+            <PRICE>$5.59</PRICE>
+            <AVAILABILITY>021699</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Spring-Beauty</COMMON>
+            <BOTANICAL>Claytonia Virginica</BOTANICAL>
+            <ZONE>7</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$6.59</PRICE>
+            <AVAILABILITY>020199</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Trillium</COMMON>
+            <BOTANICAL>Trillium grandiflorum</BOTANICAL>
+            <ZONE>5</ZONE>
+            <LIGHT>Sun or Shade</LIGHT>
+            <PRICE>$3.90</PRICE>
+            <AVAILABILITY>042999</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Wake Robin</COMMON>
+            <BOTANICAL>Trillium grandiflorum</BOTANICAL>
+            <ZONE>5</ZONE>
+            <LIGHT>Sun or Shade</LIGHT>
+            <PRICE>$3.20</PRICE>
+            <AVAILABILITY>022199</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Violet, Dog-Tooth</COMMON>
+            <BOTANICAL>Erythronium americanum</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$9.04</PRICE>
+            <AVAILABILITY>020199</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Trout Lily</COMMON>
+            <BOTANICAL>Erythronium americanum</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$6.94</PRICE>
+            <AVAILABILITY>032499</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Adder's-Tongue</COMMON>
+            <BOTANICAL>Erythronium americanum</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$9.58</PRICE>
+            <AVAILABILITY>041399</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Anemone</COMMON>
+            <BOTANICAL>Anemone blanda</BOTANICAL>
+            <ZONE>6</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$8.86</PRICE>
+            <AVAILABILITY>122698</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Grecian Windflower</COMMON>
+            <BOTANICAL>Anemone blanda</BOTANICAL>
+            <ZONE>6</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$9.16</PRICE>
+            <AVAILABILITY>071099</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Bee Balm</COMMON>
+            <BOTANICAL>Monarda didyma</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$4.59</PRICE>
+            <AVAILABILITY>050399</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Bergamot</COMMON>
+            <BOTANICAL>Monarda didyma</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$7.16</PRICE>
+            <AVAILABILITY>042799</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Black-Eyed Susan</COMMON>
+            <BOTANICAL>Rudbeckia hirta</BOTANICAL>
+            <ZONE>Annual</ZONE>
+            <LIGHT>Sunny</LIGHT>
+            <PRICE>$9.80</PRICE>
+            <AVAILABILITY>061899</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Buttercup</COMMON>
+            <BOTANICAL>Ranunculus</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$2.57</PRICE>
+            <AVAILABILITY>061099</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Crowfoot</COMMON>
+            <BOTANICAL>Ranunculus</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$9.34</PRICE>
+            <AVAILABILITY>040399</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Butterfly Weed</COMMON>
+            <BOTANICAL>Asclepias tuberosa</BOTANICAL>
+            <ZONE>Annual</ZONE>
+            <LIGHT>Sunny</LIGHT>
+            <PRICE>$2.78</PRICE>
+            <AVAILABILITY>063099</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Cinquefoil</COMMON>
+            <BOTANICAL>Potentilla</BOTANICAL>
+            <ZONE>Annual</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$7.06</PRICE>
+            <AVAILABILITY>052599</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Primrose</COMMON>
+            <BOTANICAL>Oenothera</BOTANICAL>
+            <ZONE>3 - 5</ZONE>
+            <LIGHT>Sunny</LIGHT>
+            <PRICE>$6.56</PRICE>
+            <AVAILABILITY>013099</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Gentian</COMMON>
+            <BOTANICAL>Gentiana</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Sun or Shade</LIGHT>
+            <PRICE>$7.81</PRICE>
+            <AVAILABILITY>051899</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Blue Gentian</COMMON>
+            <BOTANICAL>Gentiana</BOTANICAL>
+            <ZONE>4</ZONE>
+            <LIGHT>Sun or Shade</LIGHT>
+            <PRICE>$8.56</PRICE>
+            <AVAILABILITY>050299</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Jacob's Ladder</COMMON>
+            <BOTANICAL>Polemonium caeruleum</BOTANICAL>
+            <ZONE>Annual</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$9.26</PRICE>
+            <AVAILABILITY>022199</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Greek Valerian</COMMON>
+            <BOTANICAL>Polemonium caeruleum</BOTANICAL>
+            <ZONE>Annual</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$4.36</PRICE>
+            <AVAILABILITY>071499</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>California Poppy</COMMON>
+            <BOTANICAL>Eschscholzia californica</BOTANICAL>
+            <ZONE>Annual</ZONE>
+            <LIGHT>Sun</LIGHT>
+            <PRICE>$7.89</PRICE>
+            <AVAILABILITY>032799</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Shooting Star</COMMON>
+            <BOTANICAL>Dodecatheon</BOTANICAL>
+            <ZONE>Annual</ZONE>
+            <LIGHT>Mostly Shady</LIGHT>
+            <PRICE>$8.60</PRICE>
+            <AVAILABILITY>051399</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Snakeroot</COMMON>
+            <BOTANICAL>Cimicifuga</BOTANICAL>
+            <ZONE>Annual</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$5.63</PRICE>
+            <AVAILABILITY>071199</AVAILABILITY>
+        </PLANT>
+        <PLANT>
+            <COMMON>Cardinal Flower</COMMON>
+            <BOTANICAL>Lobelia cardinalis</BOTANICAL>
+            <ZONE>2</ZONE>
+            <LIGHT>Shade</LIGHT>
+            <PRICE>$3.02</PRICE>
+            <AVAILABILITY>022299</AVAILABILITY>
+        </PLANT>
+    </PLANTS>
+    <PLANT>
+        <COMMON>English ivy</COMMON>
+        <BOTANICAL>Hedera helix</BOTANICAL>
+        <ZONE>3</ZONE>
+        <LIGHT>Mostly Shady</LIGHT>
+        <PRICE>$9.99</PRICE>
+        <AVAILABILITY>000100</AVAILABILITY>
+    </PLANT>
+    <PLANT>
+        <COMMON>Dwarf periwinkle</COMMON>
+        <BOTANICAL>Vinca minor</BOTANICAL>
+        <ZONE>3</ZONE>
+        <LIGHT>Mostly Shady</LIGHT>
+        <PRICE>$12.10</PRICE>
+        <AVAILABILITY>000409</AVAILABILITY>
+    </PLANT>
+</CATALOG>

--- a/core/src/main/scala/scales/xml/parser/pull/XmlPull.scala
+++ b/core/src/main/scala/scales/xml/parser/pull/XmlPull.scala
@@ -1,25 +1,12 @@
 package scales.xml.parser.pull
 
 import javax.xml.stream._
-import scales.utils.io.{ProxiedCloseOnNeedReader, ProxiedCloseOnNeedInputStream}
+
+import scales.utils.io.{ProxiedCloseOnNeedInputStream, ProxiedCloseOnNeedReader}
 import scales.utils.resources.{CloseOnNeed, IsClosed, Pool}
-
-import scales.xml.impl
+import scales.xml.{Doc, Elem, EndElem, QName, ScalesXml, Xml10, XmlEvent, XmlItem, defaultOptimisation, defaultPathOptimisation, impl}
 import impl.{FromParser, IsFromParser}
-
-import scales.xml.{
-  ScalesXml,
-  defaultOptimisation,
-  defaultPathOptimisation,
-  Doc,
-  XmlItem,
-  Elem, EndElem,
-  Xml10,
-  XmlEvent
-  }
-
-import scales.xml.parser.strategies.{MemoryOptimisationStrategy, PathOptimisationStrategy, OptimisationToken}
-
+import scales.xml.parser.strategies.{MemoryOptimisationStrategy, OptimisationToken, PathOptimisationStrategy}
 import java.io._
 
 /**
@@ -122,7 +109,11 @@ trait XmlPulls {
   /**
    * Creates a new XmlPull based on source.  By default it will close the stream after use.
    */
-  def pullXml[RToken <: OptimisationToken](source: org.xml.sax.InputSource, optimisationStrategy : MemoryOptimisationStrategy[RToken] = defaultOptimisation, parserFactoryPool: Pool[XMLInputFactory] = impl.DefaultStaxInputFactoryPool, closeAfterUse: Boolean = true) : XmlPull with java.io.Closeable with IsClosed = {
+  def pullXml[RToken <: OptimisationToken](source: org.xml.sax.InputSource,
+                                           optimisationStrategy: MemoryOptimisationStrategy[RToken] = defaultOptimisation,
+                                           parserFactoryPool: Pool[XMLInputFactory] = impl.DefaultStaxInputFactoryPool,
+                                           closeAfterUse: Boolean = true,
+                                           strictPath: List[QName] = Nil) : XmlPull with java.io.Closeable with IsClosed = {
     val stream = sourceUser(source)
 
     val pf = parserFactoryPool.grab
@@ -153,6 +144,7 @@ trait XmlPulls {
         }
       }
 
+      override val iStrictPath = strictPath
       start
     }
   }

--- a/project/ScalesXmlRoot.scala
+++ b/project/ScalesXmlRoot.scala
@@ -119,7 +119,7 @@ object ScalesXmlRoot extends Build {
 //    organization := "org.scalesxml",
     offline := true,
     version := "0.6.0-M4",
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.8",
 //    scalaVersion := "2.10.0-M7",
     crossScalaVersions := Seq("2.11.6","2.10.4"),
     //publishSetting,


### PR DESCRIPTION
A proposal for solving [lazy-parsing-the-elements-in-huge-xml](http://stackoverflow.com/questions/39955894/lazy-parsing-the-elements-in-huge-xml)

- what was the problem? - no quick way for pulling elements at the end of huge file without parsing the whole thing
- why the existing features were not sufficient? - it used to take all tags from all levels of xml tree
- what is the general approach we used? - we introduced an optional _strictPath_ argument for _pullXml_ in order to quickly skip tags which don't match a strictPath i.e. tag lies on wrong level of tree 
- how can others reuse it? - by specifying _strictPath_ as an additional parameter of _pullXml_ method

Take a look at _testIteratorForStrictSelectivePulling_ for details 